### PR TITLE
Change async attribute to defer on js library script tags

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -17,12 +17,12 @@ layout: compress
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/clusterize.js/0.19.0/clusterize.min.css"
     integrity="sha512-8KLHxyeJ2I3BzL2ma1RZxwT1cc/U5Rz/uJg+G25tCrQ8sFfPz3MfJdKZegZDPijTxK2A3+b4kAXvzyK/OLLU5A=="
     crossorigin="anonymous" referrerpolicy="no-referrer" />
-  <script async id="clusterize-script"
+  <script defer id="clusterize-script"
     src="https://cdnjs.cloudflare.com/ajax/libs/clusterize.js/0.19.0/clusterize.min.js"
     integrity="sha512-sCslfbDbPoJepZJxo6S3mdJwYYt0SX+C9G1SYez6/yGuXcPrZXM9tqZQMpujvMZlujVve98JSzimWbYAlQzvFQ=="
     crossorigin="anonymous" referrerpolicy="no-referrer"></script>
   <link rel="stylesheet" href="/nouislider.css">
-  <script async src="https://cdnjs.cloudflare.com/ajax/libs/noUiSlider/15.7.0/nouislider.min.js"
+  <script defer src="https://cdnjs.cloudflare.com/ajax/libs/noUiSlider/15.7.0/nouislider.min.js"
     integrity="sha512-UOJe4paV6hYWBnS0c9GnIRH8PLm2nFK22uhfAvsTIqd3uwnWsVri1OPn5fJYdLtGY3wB11LGHJ4yPU1WFJeBYQ=="
     crossorigin="anonymous" referrerpolicy="no-referrer"></script>
   <script>


### PR DESCRIPTION
This PR replaces the `async` attribute with a `defer` attribute on the script tags for the Clusterize.js and noUiSlider libraries. This is to prevent an issue that happens currently where sometimes the script.js file gets run first and the libraries arent accesible, leading to a broken list view. Defer prevents this since it forces scripts to be executed in the order they are defined in the html, leading to script.js being executed last when all its dependencies are loaded.